### PR TITLE
Optimized boot loader loop and made various fixes

### DIFF
--- a/Bootloader/boot.asm
+++ b/Bootloader/boot.asm
@@ -42,7 +42,7 @@ ReadSectors:
         int 0x13
 
         add dword [DAP+8], 127  ; increment sector count
-        add word [DAP+6], 0xFE0 ; (512*127) >> 16
+        add word [DAP+6], 0xFE0 ; (512*127) >> 4
 
         pop cx
         loop .loop

--- a/Bootloader/boot.asm
+++ b/Bootloader/boot.asm
@@ -5,6 +5,8 @@
 
 BootMain:
         ;Setup Data
+        cli
+        cld
         xor     ax, ax
         mov     ds, ax
         mov     es, ax
@@ -12,6 +14,9 @@ BootMain:
         ;Setup Stack
         mov     sp, 0x7C00
         mov     ss, ax
+        sti
+
+        mov [bootdisk], dl
 
         ;Setup VESA (640x480 8bpp)
         mov     ax, 0x4F02
@@ -25,88 +30,26 @@ BootMain:
 
 ;---------------------------------------
 
-;I tried optimizing this part
-;However I couldn't get it...
-;If you solve it make a pull request!
 ReadSectors:
-        mov     ah, 0x42
-        mov     si, DAP
-        int     0x13
+        mov cx, 10      ; counter
 
-        mov     bx, (KERNEL + 127 * 512) >> 4
-        mov     word [DAP + 6], bx
-        mov     word [DAP + 8], 128
+.loop:
+        push cx
 
-        mov     ah, 0x42
-        mov     si, DAP
-        int     0x13
+        mov ah, 0x42
+        mov dl, [bootdisk]
+        mov si, DAP
+        int 0x13
 
-        mov     bx, (KERNEL + (127 * 2) * 512) >> 4
-        mov     word [DAP + 6], bx
-        add     word [DAP + 8], 127
+        add dword [DAP+8], 127  ; increment sector count
+        add word [DAP+6], 0xFE0 ; (512*127) >> 16
 
-        mov     ah, 0x42
-        mov     si, DAP
-        int     0x13
-
-        mov     bx, (KERNEL + (127 * 3) * 512) >> 4
-        mov     word [DAP + 6], bx
-        add     word [DAP + 8], 127
-
-        mov     ah, 0x42
-        mov     si, DAP
-        int     0x13
-
-        mov     bx, (KERNEL + (127 * 4) * 512) >> 4
-        mov     word [DAP + 6], bx
-        add     word [DAP + 8], 127
-
-        mov     ah, 0x42
-        mov     si, DAP
-        int     0x13
-
-        mov     bx, (KERNEL + (127 * 5) * 512) >> 4
-        mov     word [DAP + 6], bx
-        add     word [DAP + 8], 127
-
-        mov     ah, 0x42
-        mov     si, DAP
-        int     0x13
-
-        mov     bx, (KERNEL + (127 * 6) * 512) >> 4
-        mov     word [DAP + 6], bx
-        add     word [DAP + 8], 127
-
-        mov     ah, 0x42
-        mov     si, DAP
-        int     0x13
-
-        mov     bx, (KERNEL + (127 * 7) * 512) >> 4
-        mov     word [DAP + 6], bx
-        add     word [DAP + 8], 127
-
-        mov     ah, 0x42
-        mov     si, DAP
-        int     0x13
-
-        mov     bx, (KERNEL + (127 * 8) * 512) >> 4
-        mov     word [DAP + 6], bx
-        add     word [DAP + 8], 127
-
-        mov     ah, 0x42
-        mov     si, DAP
-        int     0x13
-
-        mov     bx, (KERNEL + (127 * 9) * 512) >> 4
-        mov     word [DAP + 6], bx
-        add     word [DAP + 8], 127
-
-        mov     ah, 0x42
-        mov     si, DAP
-        int     0x13
+        pop cx
+        loop .loop
 
         ret
 
+align 4
 DAP:
         db      0x10        ;DAP     byte [dap+0]
         db      0x00        ;Unused  byte [dap+1]
@@ -114,6 +57,8 @@ DAP:
         dw      0x0000      ;Segment byte [dap+3] byte [dap+4]
         dw      KERNEL >> 4 ;Offset  word [DAP+6]
         dq      1           ;LBA      word [DAP+8]
+
+bootdisk:       db 0
 
 ;---------------------------------------
 


### PR DESCRIPTION
This PR optimizes the main `ReadSectors` loop body in the boot loader. It also makes several minor fixes in assumptions of the CPU's state, such as disabling interrupts before modifying the stack segment and stack pointer as well as clearing the direction flag. It also stores the boot device number as the DL register is not guaranteed to be preserved by BIOS INT 13h. Finally, it aligns the DAP structure to 4-byte boundary as this is allegedly required by some firmwares.

However, this PR does not acknowledge the fact that there is still no error checking nor any form of sector count validation, and I did not try to add those because I presume you will eventually move to using a persistent file system someday.

Nevertheless, this fix reduces the code size by quite a bit and makes it considerably easier to read.