### PR TITLE
Fix kernel hangs on absent SB16 and empty IDE channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# ------------------------------------------------------
+# NovaOS build outputs
+# ------------------------------------------------------
+
+# Object tree produced by the Makefile ($(BIN))
+/Binaries/
+
+# Standalone objects built outside $(BIN)
+/Bootloader/boot.o
+/Kernel/gfx/gears.o
+
+# Linked kernel and the ISO built by `make`
+/fullkernel
+/NovaOS/boot/kernel
+/NovaOS.iso
+
+# ------------------------------------------------------
+# Runtime files created by `make run` / run.bat
+# ------------------------------------------------------
+
+/disk.raw
+/net.pcap
+*.log
+
+# ------------------------------------------------------
+# Editor and OS noise
+# ------------------------------------------------------
+
+.vscode/
+.idea/
+*.swp
+*~
+.DS_Store
+Thumbs.db

--- a/Drivers/sb16.c
+++ b/Drivers/sb16.c
@@ -11,16 +11,43 @@
 
 int playing;
 
+//0x00 when no card answered the DSP reset, so we never talk to dead ports
+static int present;
+
 void ResetSoundBlaster()
 {
+    present = 0x00;
+
     outb(0x226, 0x01);
+    for (volatile int i = 0; i < 10000; i++);
     outb(0x226, 0x00);
+
+    //A real DSP raises bit 7 of the read-buffer status and answers 0xAA
+    for (int i = 0; i < 100000; i++)
+    {
+        if ((inb(0x22E) & 0x80) != 0x00)
+        {
+            if (inb(0x22A) == 0xAA) present = 0x01;
+            break;
+        }
+    }
 }
 
 void WriteDSP(BYTE cmd)
 {
-    while ((inb(0x22C) & 0x80) != 0x00);
-    outb(0x22C, cmd);
+    if (!present) return;
+
+    //Bounded wait: an absent card floats the port high and would spin forever
+    for (int i = 0; i < 100000; i++)
+    {
+        if ((inb(0x22C) & 0x80) == 0x00)
+        {
+            outb(0x22C, cmd);
+            return;
+        }
+    }
+
+    present = 0x00;
 }
 
 void SoundBlasterHandler()
@@ -57,6 +84,8 @@ void SetupDMA(LPBYTE buffer, WORD size)
 
 void SoundBlasterPlay(LPBYTE buffer, WORD size)
 {
+    if (!present) return;
+
     playing = 0x01;
 
     // Configurar DMA antes de iniciar a reprodução

--- a/Hardware/disk.c
+++ b/Hardware/disk.c
@@ -10,17 +10,30 @@
 
 #include "disk.h"
 
-void WaitForReady(WORD base)
+int WaitForReady(WORD base)
 {
-    while (1) 
+    for (int i = 0; i < 100000; i++)
     {
-        BYTE status = inw(base + 7);
+        BYTE status = inb(base + 7);
 
-        if (status & IDE_STATUS_READY) 
+        //An empty channel floats to 0x00 or 0xFF, so there is nothing to wait for
+        if (status == 0x00 || status == 0xFF)
         {
-            break;
+            return 0x00;
+        }
+
+        if (status & IDE_STATUS_ERROR)
+        {
+            return 0x00;
+        }
+
+        if ((status & IDE_STATUS_BUSY) == 0x00 && (status & IDE_STATUS_READY))
+        {
+            return 0x01;
         }
     }
+
+    return 0x00;
 }
 
 DWORD GetDiskCapacity(WORD base)
@@ -28,7 +41,10 @@ DWORD GetDiskCapacity(WORD base)
     outw(base + 6, 0xA0);
     outw(base + 7, 0xEC);
 
-    WaitForReady(base);
+    if (!WaitForReady(base))
+    {
+        return 0;
+    }
 
     WORD data[256];
 

--- a/Hardware/disk.h
+++ b/Hardware/disk.h
@@ -2,11 +2,12 @@
 #define IDE_PRIMARY_CONTROL_PORT   0x3F6
 #define IDE_STATUS_READY           0x40
 #define IDE_STATUS_ERROR           0x01
+#define IDE_STATUS_BUSY            0x80
 
 #define FLOPPY_STATUS_PORT         0x3F0
 #define FLOPPY_READY               0x80
 
-void WaitForReady(WORD base);
+int WaitForReady(WORD base);
 DWORD GetDiskCapacity(WORD base);
 DWORD GetFloppyCapacity(void);
 void ListDisks(void);

--- a/README.md
+++ b/README.md
@@ -68,11 +68,13 @@ https://github.com/user-attachments/assets/696a708d-3408-4850-8edd-a12c05431517
 
 # ⚙️ Building
 ### 🧰 Necessary Components
-gcc and nasm
+`gcc`, `nasm`, `xorriso`, `grub-pc-bin`, `mtools`.
+`grub-pc-bin` is what supplies the BIOS boot image, without it `grub-mkrescue` silently produces a non-bootable ISO.
 ### 📄 Compiling
-Run the Makefile using make 
+Run the Makefile using `make`. Confirm the output with `file NovaOS.iso`, which must report `(bootable)`.
 ### 🚀 Running
-use run.bat for Windows.
+Use `make run` on Linux, or `run.bat` for Windows.
+NovaOS starts in the text shell — type `gfx` at the prompt to launch the GUI.
 
 # 🤝 Contribute
 NovaOS is an Open Source project, so everyone can contibute for it! You can help me starring/forking this project or help with code using pull requests (and optimize more!)


### PR DESCRIPTION
## Don't hang at boot when there's no Sound Blaster or IDE disk

I tried booting the current ISO in QEMU and never got to the shell. It turned out
to be two separate hangs that are really the same mistake, so I've fixed both here.

```c
qemu-system-x86_64 -cdrom NovaOS.iso
```

### The Sound Blaster one

Boot stops dead right after `[  OK  ] Memory Initialized!` The next thing the kernel does is `SetupSoundBlaster()`, and `WriteDSP()`
had this:

```c
while ((inb(0x22C) & 0x80) != 0x00);
```

With no card at 0x220 the ISA port floats and inb returns 0xFF. 0xFF & 0x80 is
never zero, so the loop never exits. It only ever worked because make run passes
-device sb16, boot without a card, or with a plain qemu-system-x86_64 -cdrom,
and you're stuck forever.

ResetSoundBlaster() now does a real reset and waits for the 0xAA ready byte to
find out whether anything is actually there. If nothing answers, WriteDSP() and
SoundBlasterPlay() return instead of poking dead ports, and the waits that remain
are bounded.

### The IDE one

Same story one function later. Get past the SB16 and it hangs after
[ INFO ] Total CMOS Memory Size:, which is ListDisks():

while (1) { BYTE status = inw(base + 7); if (status & IDE_STATUS_READY) break; }

An empty IDE channel reads back 0x00, so DRDY never sets. This one catches anyone
running with -cdrom, since that maps to index 2 and leaves the primary channel
empty. WaitForReady() now reports whether it succeeded, treats 0x00/0xFF as
"nothing here", honours ERR and waits for BSY to clear like it should.
GetDiskCapacity() returns 0 on failure, so you get the "No Disk Found" message
that was already written for it.

### Docs

Not part of the fix, but it's how I ended up here. The README says you need "gcc and
nasm" and that isn't enough, 'grub-mkrescue' needs grub-pc-bin for the BIOS boot otherwise it becomes a non bootable ISO.